### PR TITLE
Add remove from cart functionality

### DIFF
--- a/.byebug_history
+++ b/.byebug_history
@@ -1,4 +1,10 @@
 exit
+@cart
+@cart.contents.delete(params[:id])
+@cart.contents
+@cart
+Item.find(params[:id])
+exit
 @cart.items[0][1]
 @cart.items[0][0]
 @cart.items[1]

--- a/app/controllers/cart_items_controller.rb
+++ b/app/controllers/cart_items_controller.rb
@@ -12,7 +12,6 @@ class CartItemsController < ApplicationController
 
 	def destroy
 		@item = Item.find(params[:id])
-		# binding.pry
 		flash_link = "#{view_context.link_to @item.title, item_path(@item)}"
 		flash[:success] = {color: "green", message: "Successfully removed #{flash_link} from your cart."}
 		@cart.contents.delete(params[:id])

--- a/app/controllers/cart_items_controller.rb
+++ b/app/controllers/cart_items_controller.rb
@@ -1,5 +1,6 @@
 class CartItemsController < ApplicationController
 	include ActionView::Helpers::TextHelper
+	include ActionView::Helpers::UrlHelper
 
 	def create
 		item = Item.find(params[:item_id])
@@ -7,5 +8,14 @@ class CartItemsController < ApplicationController
 		session[:cart] = @cart.contents
 		flash[:notice] = "You have #{pluralize(@cart.count_of, "item")} in your cart."
 		redirect_to '/items'
+	end
+
+	def destroy
+		@item = Item.find(params[:id])
+		# binding.pry
+		flash_link = "#{view_context.link_to @item.title, item_path(@item)}"
+		flash[:success] = {color: "green", message: "Successfully removed #{flash_link} from your cart."}
+		@cart.contents.delete(params[:id])
+		redirect_to cart_path
 	end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,4 +4,8 @@ class ItemsController < ApplicationController
     @items = Item.all
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
 end

--- a/app/views/carts/_cart_items.html.erb
+++ b/app/views/carts/_cart_items.html.erb
@@ -1,8 +1,9 @@
 <tr>
+  <td><%= image_tag item[0].image_url, height: '300', width: '300', id: "#{item[0].id}_item" %></td>
   <td><%= item[0].title %></td>
   <td><%= item[0].description %></td>
-  <td><%= item[0].price %></td>
-  <td><%= image_tag item[0].image_url, height: '300', width: '300', id: "#{item[0].id}_item" %></td>
   <td><%= item[0].travesty.title %></td>
+  <td><%= item[0].price %></td>
   <td><%= "Amount: #{item[1]}" %></td>
+  <td><%= link_to "Remove", cart_item_path(item[0]), method: :delete %></td>
 </tr>

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -2,12 +2,13 @@
 <table class="bordered striped highlight centered responsive-table">
   <thead>
     <tr>
+      <th data-field="Image">Image</th>
       <th data-field="Title">Title</th>
       <th data-field="Description">Description</th>
-      <th data-field="Price">Price ($)</th>
-      <th data-field="Image">Image</th>
       <th data-field="Travesty">Travesty</th>
+      <th data-field="Price">Price ($)</th>
       <th data-field="Amount">Amount</th>
+      <th data-field="Remove Item">Remove Item</th>
     </th>
   </tr>
 </thead>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,0 +1,1 @@
+<%= render :item, locals: { item: @item } %>

--- a/app/views/layouts/_flash_card.html.erb
+++ b/app/views/layouts/_flash_card.html.erb
@@ -1,0 +1,5 @@
+<div class="row">
+  <div class="col s12 m5">
+      <%= content_tag :div, (content_tag :span, sanitize(message), class: "flash_#{color}_card"), class: "card-panel #{color}" %> 
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,8 +14,12 @@
 
   <div class="container-fluid" style="padding: 50px" >
 
-    <% flash.each do |type, message| %>
-    <%= content_tag :div, message %>
+    <% flash.each do |type, hash| %>
+      <% if type == "success" %>
+        <%= render partial: "layouts/flash_card", locals: {message: hash["message"], color: hash["color"]} %>
+      <% else %>
+        <%= render partial: "layouts/flash_card", locals: {message: hash, color: "white"} %>
+      <% end %>
     <% end %>
 
     <%= yield %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
 
   resources :users, only: [:new, :create]
 
-  resources :items, only: [:index]
+  resources :items, only: [:index, :show]
 
   get '/dashboard', to: 'users#show'
 
@@ -14,5 +14,5 @@ Rails.application.routes.draw do
 
   get '/cart', to: 'carts#show'
 
-  resources :cart_items, only: [:create]
+  resources :cart_items, only: [:create, :destroy]
 end

--- a/spec/features/visitor_can_add_items_to_carts_spec.rb
+++ b/spec/features/visitor_can_add_items_to_carts_spec.rb
@@ -6,8 +6,6 @@ RSpec.feature "visitor can add items to cart" do
     db_repo = FactoryJordan.new
     db_repo.create_travesty("Environmental Disasters")
 
-    item_1 = db_repo.items[0]
-
     visit '/items'
 
     expect(page).to have_content("My Cart: 0")

--- a/spec/features/visitor_can_remove_items_from_cart_spec.rb
+++ b/spec/features/visitor_can_remove_items_from_cart_spec.rb
@@ -6,8 +6,6 @@ RSpec.feature "visitor can remove items from cart" do
     db_repo = FactoryJordan.new
     db_repo.create_travesty("Environmental Disasters")
 
-    item_1 = db_repo.items[0]
-
     visit '/items'
 
     first(:button, 'Add to cart').click
@@ -19,7 +17,6 @@ RSpec.feature "visitor can remove items from cart" do
 
     first(:link, "Remove").click
 
-    save_and_open_page
     expect(current_path).to eq(cart_path)
     find_link('Oil Barrel Dump').visible?
     expect(page).to have_content("Successfully removed Oil Barrel Dump from your cart.")

--- a/spec/features/visitor_can_remove_items_from_cart_spec.rb
+++ b/spec/features/visitor_can_remove_items_from_cart_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.feature "visitor can remove items from cart" do
+  scenario "cart shows no items in cart after removal" do
+
+    db_repo = FactoryJordan.new
+    db_repo.create_travesty("Environmental Disasters")
+
+    item_1 = db_repo.items[0]
+
+    visit '/items'
+
+    first(:button, 'Add to cart').click
+
+    expect(page).to have_content("My Cart: 1")
+    expect(page).to have_content("You have 1 item in your cart.")
+
+    visit '/cart'
+
+    first(:link, "Remove").click
+
+    save_and_open_page
+    expect(current_path).to eq(cart_path)
+    find_link('Oil Barrel Dump').visible?
+    expect(page).to have_content("Successfully removed Oil Barrel Dump from your cart.")
+    expect(page).to have_css(".flash_green_card")
+    expect(page).to_not have_content("My Cart: 1")
+    expect(page).to have_content("My Cart: 0")
+  end
+end


### PR DESCRIPTION
Added functionality for removing items from a cart.
When doing so, displays a flash card with message and link to removed item page.
Additionally will show cards for any flash messages, with default to white background on the card.
