### PR TITLE
Add cart fixes for updating quantity of 0, and total item count

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -15,7 +15,12 @@ class UsersController < ApplicationController
   end
 
   def show
-    @user = User.find(session[:user_id])
+    if session[:user_id]
+      @user = User.find(session[:user_id])
+      redirect_to dashboard_path
+    else
+      redirect_to root_path
+    end
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,7 +17,6 @@ class UsersController < ApplicationController
   def show
     if session[:user_id]
       @user = User.find(session[:user_id])
-      redirect_to dashboard_path
     else
       redirect_to root_path
     end

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -11,7 +11,7 @@ class Cart
   end
 
 	def count_of
-		contents.values.reduce(:+)
+		contents.values.reduce(:+) || 0
 	end
 
 	def items

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -11,7 +11,7 @@ class Cart
   end
 
 	def count_of
-		contents.length
+		contents.values.reduce(:+)
 	end
 
 	def items
@@ -29,6 +29,9 @@ class Cart
 		item_id = qty_update_data["item_id"]
 		new_qty = qty_update_data["quantity"].to_i
 		contents[item_id] = new_qty
+		if new_qty == 0
+			contents.delete(item_id)
+		end
 	end
 
 	def delete_item(item_id)

--- a/spec/features/visitor_can_add_items_to_carts_spec.rb
+++ b/spec/features/visitor_can_add_items_to_carts_spec.rb
@@ -8,6 +8,7 @@ RSpec.feature "visitor can add items to cart" do
 
     visit '/items'
 
+    save_and_open_page
     expect(page).to have_content("My Cart: 0")
 
     first(:button, 'Add to cart').click

--- a/spec/features/visitor_can_add_items_to_carts_spec.rb
+++ b/spec/features/visitor_can_add_items_to_carts_spec.rb
@@ -8,7 +8,6 @@ RSpec.feature "visitor can add items to cart" do
 
     visit '/items'
 
-    save_and_open_page
     expect(page).to have_content("My Cart: 0")
 
     first(:button, 'Add to cart').click


### PR DESCRIPTION
Added functionality to cart:

  If quantity of a cart item is updated to be 0, item is removed from the cart.
  Cart item total now shows total number of items in cart, not just unique item count.

Additionally changed the users controller to redirect a guest to the root if they
attempt to access the dashboard.
