### PR TITLE
User logging in with incorrect credentials will be redirected

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,7 +6,7 @@ class SessionsController < ApplicationController
 
   def create
     @user = User.find_by(username: params[:session][:username])
-    if @user.admin?
+    if @user && @user.admin?
       session[:user_id] = @user.id
       redirect_to admin_dashboard_path
     elsif @user && @user.authenticate(params[:session][:password])
@@ -14,8 +14,8 @@ class SessionsController < ApplicationController
       flash[:success] = {color: 'green', message: "Logged in as #{@user.first_name}"}
       redirect_to dashboard_path
     else
-      flash[:error] = {color: 'orange', message: "Username or Password incorrect."}
-      render :new
+      flash[:error] = {color: 'orange', message: "Username or password incorrect."}
+      redirect_to '/login'
     end
   end
 

--- a/spec/features/user_can_login_account_spec.rb
+++ b/spec/features/user_can_login_account_spec.rb
@@ -29,4 +29,36 @@ RSpec.feature "user can login account from home" do
     expect(page).to_not have_content "Login"
     expect(page).to have_content "Logout"
   end
+
+  scenario "I get redirected if my credentials are not correct" do
+    User.create(
+                first_name: "Jordan",
+                last_name: "Lawler",
+                username: "jlawlz",
+                password: "password"
+                )
+
+    visit '/login'
+    fill_in "Username", with: "jlawlz"
+    fill_in "Password", with: "wrong"
+
+    click_button "Submit"
+
+    expect(current_path).to eq '/login'
+    expect(page).to have_content "Username or password incorrect."
+
+    fill_in "Username", with: "jlawlzzz"
+    fill_in "Password", with: "password"
+    click_button "Submit"
+
+    expect(page).to have_content "Username or password incorrect."
+    expect(current_path).to eq '/login'
+
+    fill_in "Username", with: "jlawlzzz"
+    fill_in "Password", with: "wrong"
+    click_button "Submit"
+
+    expect(page).to have_content "Username or password incorrect."
+    expect(current_path).to eq '/login'
+  end
 end


### PR DESCRIPTION
Incorrect credentials had been crashing the site, because @user.admin? would throw
error if user is nil.

Add test to confirm this functionality, update sessions_controller.
